### PR TITLE
Fix Discord/Antigravity relogin on boot via KWallet auto-unlock

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -92,22 +92,19 @@
 
   programs.noisetorch.enable = true;
 
-  # Define a user account. Blank password: SDDM still runs the real
-  # login/PAM flow (so pam_kwallet unlocks KWallet, fixing Discord/Antigravity
-  # getting logged out on every boot), you just don't have to type anything.
+  # Define a user account. Don't forget to set a password with 'passwd'.
+  # No autoLogin: SDDM needs the real login/PAM flow to run so pam_kwallet
+  # unlocks KWallet with your password. That's what was fixing
+  # Discord/Antigravity getting logged out on every boot.
   users.users.km = {
     isNormalUser = true;
     description = "km";
-    hashedPassword = "";
     extraGroups = [ "networkmanager" "wheel" ];
     packages = with pkgs; [
       kdePackages.kate
     #  thunderbird
     ];
   };
-
-  # Allow logging in with a blank password on the greeter's PAM stack.
-  security.pam.services.login.allowNullPassword = true;
 
   # Fonts
   fonts.packages = with pkgs; [

--- a/configuration.nix
+++ b/configuration.nix
@@ -92,10 +92,13 @@
 
   programs.noisetorch.enable = true;
 
-  # Define a user account. Don't forget to set a password with ‘passwd’.
+  # Define a user account. Blank password: SDDM still runs the real
+  # login/PAM flow (so pam_kwallet unlocks KWallet, fixing Discord/Antigravity
+  # getting logged out on every boot), you just don't have to type anything.
   users.users.km = {
     isNormalUser = true;
     description = "km";
+    hashedPassword = "";
     extraGroups = [ "networkmanager" "wheel" ];
     packages = with pkgs; [
       kdePackages.kate
@@ -103,9 +106,8 @@
     ];
   };
 
-  # Enable automatic login for the user.
-  services.displayManager.autoLogin.enable = true;
-  services.displayManager.autoLogin.user = "km";
+  # Allow logging in with a blank password on the greeter's PAM stack.
+  security.pam.services.login.allowNullPassword = true;
 
   # Fonts
   fonts.packages = with pkgs; [

--- a/modules/home-manager/low_level/plasma.nix
+++ b/modules/home-manager/low_level/plasma.nix
@@ -2,7 +2,7 @@
 {
   programs.plasma = {
     enable = true;
-    
+
     workspace = {
       theme = "breeze-dark";
       colorScheme = "BreezeDark";


### PR DESCRIPTION
## Summary
- Discord and Antigravity (both Electron apps) encrypt their local session tokens via `libsecret`/KWallet. With SDDM autologin enabled, the password-entry step (and thus `pam_kwallet`'s auto-unlock) never ran, so KWallet stayed locked every boot and both apps lost access to their stored login tokens, forcing a re-login each restart.
- Removed `services.displayManager.autoLogin` and instead set the `km` user's password to blank (`hashedPassword = ""`) with `security.pam.services.login.allowNullPassword = true`. SDDM now runs the real login/PAM flow (so `pam_kwallet` unlocks the wallet as intended) without requiring you to actually type anything.
- Minor whitespace cleanup in `plasma.nix`.

## Test plan
- [ ] `nixos-rebuild switch` and reboot
- [ ] Confirm SDDM logs in without typing a password
- [ ] Confirm Discord and Antigravity stay logged in after a full restart